### PR TITLE
Fix UI theme bug and extend utility coverage

### DIFF
--- a/README.md
+++ b/README.md
@@ -128,7 +128,7 @@ flutter pub get
 ### 2. Generate Code
 
 ```bash
-flutter packages pub run build_runner build
+flutter pub run build_runner build
 ```
 
 ### 3. Run the Application

--- a/TESTING_GUIDE.md
+++ b/TESTING_GUIDE.md
@@ -1,4 +1,6 @@
-# 📋 ส## 🎯 **ผลลัพธ์สุดท้าย: 161/161 tests ผ่าน (100% Success Rate)** 🏆ุปผลการทดสอบ Unit Tests สำหรับ Flutter MVVM+DDD Template
+# 📋 สรุปผลการทดสอบ Unit Tests สำหรับ Flutter MVVM+DDD Template
+
+## 🎯 **ผลลัพธ์สุดท้าย: 161/161 tests ผ่าน (100% Success Rate)** 🏆
 
 ## 🎯 วัตถุประสงค์ของการทดสอบ
 

--- a/lib/app.dart
+++ b/lib/app.dart
@@ -30,7 +30,12 @@ class MyApp extends StatelessWidget {
           useMaterial3: true,
           colorScheme: ColorScheme.fromSeed(seedColor: Colors.blue, brightness: Brightness.light),
           appBarTheme: const AppBarTheme(centerTitle: true, elevation: 0),
-          cardTheme: const CardThemeData(elevation: 2, shape: RoundedRectangleBorder(borderRadius: BorderRadius.all(Radius.circular(12)))),
+          cardTheme: const CardTheme(
+            elevation: 2,
+            shape: RoundedRectangleBorder(
+              borderRadius: BorderRadius.all(Radius.circular(12)),
+            ),
+          ),
           elevatedButtonTheme: ElevatedButtonThemeData(
             style: ElevatedButton.styleFrom(
               padding: const EdgeInsets.symmetric(horizontal: 24, vertical: 12),

--- a/test/core/utils_test.dart
+++ b/test/core/utils_test.dart
@@ -1,0 +1,52 @@
+import 'package:blueprint_application/core/utils.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+void main() {
+  group('AppUtils date helpers', () {
+    test('formatDate should use yyyy-MM-dd pattern', () {
+      final date = DateTime(2024, 5, 4);
+      expect(AppUtils.formatDate(date), '2024-05-04');
+    });
+
+    test('parseDate should return null for invalid input', () {
+      expect(AppUtils.parseDate('not-a-date'), isNull);
+    });
+
+    test('parseDateTime should roundtrip formatted value', () {
+      final original = DateTime(2024, 5, 4, 13, 45, 30);
+      final formatted = AppUtils.formatDateTime(original);
+      final parsed = AppUtils.parseDateTime(formatted);
+
+      expect(parsed, isNotNull);
+      expect(parsed, equals(DateTime(2024, 5, 4, 13, 45, 30)));
+    });
+  });
+
+  group('AppUtils string helpers', () {
+    test('truncateText should append ellipsis when exceeding max length', () {
+      const source = 'A very long sentence that needs truncation';
+      expect(AppUtils.truncateText(source, 10), 'A very long...');
+    });
+
+    test('capitalizeFirst should return original text for empty input', () {
+      expect(AppUtils.capitalizeFirst(''), isEmpty);
+    });
+
+    test('capitalizeFirst should only affect the first character', () {
+      expect(AppUtils.capitalizeFirst('hELLO'), 'Hello');
+    });
+  });
+
+  group('AppUtils url helpers', () {
+    test('isValidUrl should validate http and https schemes', () {
+      expect(AppUtils.isValidUrl('https://example.com'), isTrue);
+      expect(AppUtils.isValidUrl('http://example.com'), isTrue);
+      expect(AppUtils.isValidUrl('ftp://example.com'), isFalse);
+    });
+
+    test('extractDomain should return host from url', () {
+      expect(AppUtils.extractDomain('https://sub.example.com/path'), 'sub.example.com');
+      expect(AppUtils.extractDomain(null), isNull);
+    });
+  });
+}


### PR DESCRIPTION
## Summary
- replace the invalid `CardThemeData` usage with the stable `CardTheme` configuration to keep Material theming compile-safe
- clean up introductory docs by fixing the corrupted Thai heading in the testing guide and modernizing the build runner command
- add focused unit tests for `AppUtils` date, string, and URL helpers to guard against regressions

## Testing
- `flutter test` *(fails: command not found in environment)*

------
https://chatgpt.com/codex/tasks/task_e_68db3887f8c0832bb005cb8d19298dd6